### PR TITLE
Enabling possibility of adding tags to RDS resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This module makes the following assumptions:
 - `copy_tags_to_snapshot` - copy all tags from RDS database to snapshot (default `true`)
 - `backup_retention_period` - backup retention period in days (default: 0), must be `> 0` to enable backups
 - `backup_window` - when to perform DB snapshot, default "22:00-03:00"; can't overlap with maintenance window
+- `tags` - A mapping of tags to assign to the resource.
 
 ## Outputs
 
@@ -106,6 +107,11 @@ module "my_rds_instance" {
     subnets = ["${aws_subnet.example.*.id}"] # see above
     rds_vpc_id = "${module.vpc}"
     private_cidr = "${var.private_cidr}"
+
+    tags {
+        "Terraform" = "true"
+        "Env" = "${terraform.env}"
+    }
 }
 ```
 
@@ -133,6 +139,7 @@ module "my_rds_instance" {
 - `copy_tags_to_snapshot`
 - `backup_retention_period`
 - `backup_window`
+- `tags`
 
 # Authors
 

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,9 @@ resource "aws_db_instance" "main_rds_instance" {
 
     backup_retention_period = "${var.backup_retention_period}"
     backup_window = "${var.backup_window}"
-}
 
+    tags = "${merge(var.tags, map("Name", format("%s", var.rds_instance_identifier)))}"
+} 
 resource "aws_db_parameter_group" "main_rds_instance" {
     name = "${var.rds_instance_identifier}-${replace(var.db_parameter_group, ".", "")}-custom-params"
     family = "${var.db_parameter_group}"
@@ -56,12 +57,16 @@ resource "aws_db_parameter_group" "main_rds_instance" {
     #   name = "character_set_client"
     #   value = "utf8"
     # }
+
+    tags = "${merge(var.tags, map("Name", format("%s", var.rds_instance_identifier)))}"
 }
 
 resource "aws_db_subnet_group" "main_db_subnet_group" {
     name = "${var.rds_instance_identifier}-subnetgrp"
     description = "RDS subnet group"
     subnet_ids = ["${var.subnets}"]
+
+    tags = "${merge(var.tags, map("Name", format("%s", var.rds_instance_identifier)))}"
 }
 
 # Security groups
@@ -69,6 +74,8 @@ resource "aws_security_group" "main_db_access" {
   name = "Database access"
   description = "Allow access to the database"
   vpc_id = "${var.rds_vpc_id}"
+
+  tags = "${merge(var.tags, map("Name", format("%s", var.rds_instance_identifier)))}"
 }
 
 resource "aws_security_group_rule" "allow_db_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,8 @@ variable "backup_retention_period" {
     description = "How long will we retain backups"
     default = 0
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  default     = {}
+}


### PR DESCRIPTION
 It might be also needed for a kill script. Done like in the tf_aws_alb module or tf_aws_sg (https_only)