### PR TITLE
Change type of private_cidr to list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "allow_db_access" {
     from_port = "${var.database_port}"
     to_port = "${var.database_port}"
     protocol = "tcp"
-    cidr_blocks = ["${var.private_cidr}"]
+    cidr_blocks = "${var.private_cidr}"
 
     security_group_id = "${aws_security_group.main_db_access.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "subnets" {
 
 variable "private_cidr" {
     description = "VPC private addressing, used for a security group"
-    type = "string"
+    type = "list"
 }
 
 variable "rds_vpc_id" {


### PR DESCRIPTION
Current type of var.private_cidr is a string. If I have multiple private subnets I'd like var.private_cidr to be a list