### PR TITLE
feature/maintenance_window - add argument maintenance_window  and usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This module makes the following assumptions:
 - `maintenance_window` - The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC, default: "Mon:00:00-Mon:03:00"
 - `skip_final_snapshot` - if `true` (default), DB won't be backed up before deletion
 - `copy_tags_to_snapshot` - copy all tags from RDS database to snapshot (default `true`)
+- `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. Default is ""
 - `backup_retention_period` - backup retention period in days (default: 0), must be `> 0` to enable backups
 - `backup_window` - when to perform DB snapshot, default "22:00-03:00"; can't overlap with maintenance window
 - `tags` - A mapping of tags to assign to the DB instance
@@ -152,6 +153,7 @@ module "my_rds_instance" {
 - `maintenance_window`
 - `skip_final_snapshot`
 - `copy_tags_to_snapshot`
+- `snapshot_identifier`
 - `backup_retention_period`
 - `backup_window`
 - `tags`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This module makes the following assumptions:
 - `allow_major_version_upgrade` - Allow upgrading of major version of database (eg. from Postgres 9.5.x to Postgres 9.6.x), default: false
 - `auto_minor_version_upgrade` - Automatically upgrade minor version of the DB (eg. from Postgres 9.5.3 to Postgres 9.5.4), default: true
 - `apply_immediately` - Specifies whether any database modifications are applied immediately, or during the next maintenance window, default: false
+- `maintenance_window` - The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC, default: "Mon:00:00-Mon:03:00"
 - `skip_final_snapshot` - if `true` (default), DB won't be backed up before deletion
 - `copy_tags_to_snapshot` - copy all tags from RDS database to snapshot (default `true`)
 - `backup_retention_period` - backup retention period in days (default: 0), must be `> 0` to enable backups
@@ -104,6 +105,17 @@ module "my_rds_instance" {
     database_password = "${var.database_password}"
     database_port = "${var.database_port}"
 
+    # Upgrades
+    allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
+    auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
+
+    apply_immediately           = "${var.apply_immediately}"
+    maintenance_window          = "${var.maintenance_window}"
+
+    # Snapshots and backups
+    skip_final_snapshot   = "${var.skip_final_snapshot}"
+    copy_tags_to_snapshot = "${var.copy_tags_to_snapshot}"
+
     # DB Subnet Group Inputs
     subnets = ["${aws_subnet.example.*.id}"] # see above
     rds_vpc_id = "${module.vpc}"
@@ -137,6 +149,7 @@ module "my_rds_instance" {
 - `allow_major_version_upgrade`
 - `auto_minor_version_upgrade`
 - `apply_immediately`
+- `maintenance_window`
 - `skip_final_snapshot`
 - `copy_tags_to_snapshot`
 - `backup_retention_period`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This module makes the following assumptions:
 - `maintenance_window` - The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC, default: "Mon:00:00-Mon:03:00"
 - `skip_final_snapshot` - if `true` (default), DB won't be backed up before deletion
 - `copy_tags_to_snapshot` - copy all tags from RDS database to snapshot (default `true`)
-- `snapshot_identifier` - Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. Default is ""
 - `backup_retention_period` - backup retention period in days (default: 0), must be `> 0` to enable backups
 - `backup_window` - when to perform DB snapshot, default "22:00-03:00"; can't overlap with maintenance window
 - `tags` - A mapping of tags to assign to the DB instance
@@ -153,7 +152,6 @@ module "my_rds_instance" {
 - `maintenance_window`
 - `skip_final_snapshot`
 - `copy_tags_to_snapshot`
-- `snapshot_identifier`
 - `backup_retention_period`
 - `backup_window`
 - `tags`

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,6 @@ resource "aws_db_instance" "main_rds_instance" {
   # Snapshots and backups
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot = "${var.copy_tags_to_snapshot}"
-  snapshot_identifier   = "${var.snapshot_identifier}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ resource "aws_db_instance" "main_rds_instance" {
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   auto_minor_version_upgrade  = "${var.auto_minor_version_upgrade}"
   apply_immediately           = "${var.apply_immediately}"
+  maintenance_window          = "${var.maintenance_window}"
 
   # Snapshots and backups
   skip_final_snapshot   = "${var.skip_final_snapshot}"

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_db_instance" "main_rds_instance" {
   # Snapshots and backups
   skip_final_snapshot   = "${var.skip_final_snapshot}"
   copy_tags_to_snapshot = "${var.copy_tags_to_snapshot}"
+  snapshot_identifier   = "${var.snapshot_identifier}"
 
   backup_retention_period = "${var.backup_retention_period}"
   backup_window           = "${var.backup_window}"

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,11 @@ variable "copy_tags_to_snapshot" {
   default     = true
 }
 
+variable "snapshot_identifier" {
+  description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
+  default     = ""
+}
+
 variable "backup_window" {
   description = "When AWS can run snapshot, can't overlap with maintenance window"
   default     = "22:00-03:00"

--- a/variables.tf
+++ b/variables.tf
@@ -121,11 +121,6 @@ variable "copy_tags_to_snapshot" {
   default     = true
 }
 
-variable "snapshot_identifier" {
-  description = "Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05."
-  default     = ""
-}
-
 variable "backup_window" {
   description = "When AWS can run snapshot, can't overlap with maintenance window"
   default     = "22:00-03:00"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "apply_immediately" {
   default     = false
 }
 
+variable "maintenance_window" {
+  description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC "
+  default     = "Mon:00:00-Mon:03:00"
+}
+
 variable "database_name" {
   description = "The name of the database to create"
 }


### PR DESCRIPTION
- add argument `maintenance_window`, useful for the production environment.
- add argument `snapshot_identifier`, that you specify whether or not to create this database from a snapshot.
- update usage in README