### PR TITLE
#22/iops - The storage type io1 requires iops to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module makes the following assumptions:
 - `rds_is_multi_az` - Defaults to false. Set to true for a multi-az
   instance.
 - `rds_storage_type` - Defaults to standard (magnetic)
+- `rds_iops` - "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1', default is 0 if rds storage type is not io1"
 - `rds_allocated_storage` - The number of GBs to allocate. Input must be an
   integer, e.g. `10`
 - `rds_engine_type` - Engine type, such as `mysql` or `postgres`
@@ -133,6 +134,7 @@ module "my_rds_instance" {
 - `rds_instance_identifier`
 - `rds_is_multi_az`
 - `rds_storage_type`
+- `rds_iops`
 - `rds_allocated_storage`
 - `rds_engine_type`
 - `rds_engine_version`

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "aws_db_instance" "main_rds_instance" {
   # We want the multi-az setting to be toggleable, but off by default
   multi_az            = "${var.rds_is_multi_az}"
   storage_type        = "${var.rds_storage_type}"
+  iops                = "${var.rds_iops}"
   publicly_accessible = "${var.publicly_accessible}"
 
   # Upgrades

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "rds_storage_type" {
   default     = "standard"
 }
 
+variable "rds_iops" {
+  description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1', default is 0 if rds storage type is not io1"
+  default     = "0"
+}
+
 variable "rds_allocated_storage" {
   description = "The allocated storage in GBs"
 


### PR DESCRIPTION
- fix #22 
- Add option to define `iops` if rds storage type is`io1`