### PR TITLE
Add circle ci pipeline to validate the codes automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: hashicorp/terraform:0.10.0
+        entrypoint: /bin/sh
+    steps:
+      - checkout
+      - run:
+          name: validate tf files (terraform validate)
+          command: find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (terraform validate -check-variables=false "$m" && echo "√ $m") || exit 1 ; done
+      - run:
+          name: check if all tf files are formatted (terraform fmt)
+          command: if [ `terraform fmt | wc -c` -ne 0 ]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
+      - run:
+          name: "get tflint"
+          command: apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.4.2/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
+      - run:
+          name: "install tflint"
+          command: mkdir -p /usr/local/tflint/bin ; export PATH=/usr/local/tflint/bin:$PATH ; install tflint /usr/local/tflint/bin
+      - run:
+          name: "tflint check"
+          command: /usr/local/tflint/bin/tflint
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build


### PR DESCRIPTION
- Add circle ci pipeline to validate the codes automatically
- Did the same for `tf_aws_ecs` module
- upgrade terraform version to `0.10.0`
- repository owner need to add this project in circle ci. 

Successfully build at https://circleci.com/gh/BWITS/tf_aws_rds/2